### PR TITLE
Rewrite part of HandleRequest

### DIFF
--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -508,42 +508,36 @@
               (stop1/⍨~⊃1 DebugLevel 4+2×~0∊⍴ValidateRequestFn)⎕STOP⊃⎕SI
      stop1: ⍝ intentional stop for request-level debugging
               ⍬ ⎕STOP⊃⎕SI
-     
-              :If ns.Req.Response.Status=200
-                  :If 0≠Validate ns.Req  ⍝ perform any application-specified validation
-                  :AndIf 200=ns.Req.Response.Status  ⍝ if validation failed and the user did not set the status, we set it
-                      ns.Req.Fail 400
-                  :Else
-                      fn←1↓'.'@('/'∘=)ns.Req.Endpoint ⍝ endpoint/function name
-                      :If 0≠SessionTimeout ⍝ are we sessioned?
-                      :AndIf fn≡SessionStopEndpoint ⍝ and the request is to end the session
-                          :If ~0∊⍴sessId←ns.Req.GetHeader SessionIdHeader ⍝ and there's a session ID
-                              KillSession sessId ⍝ kill session/logout
-                          :Else
-                              ns.Req.Fail 400 ⍝ 400 bad request
-                          :EndIf
-                      :Else
-                          :Select lc Paradigm
-                          :Case 'json'
-                              :If HtmlInterface>(⊂ns.Req.Endpoint)∊(,'/')'/favicon.ico'
-                                  →0⍴⍨'(Request method should be POST)'ns.Req.Fail 405×'post'≢ns.Req.Method
-                                  →0⍴⍨'(Bad URI)'ns.Req.Fail 400×'/'≠⊃ns.Req.Endpoint
-                                  →0⍴⍨'(Content-Type should be application/json)'ns.Req.Fail 400×(0∊⍴ns.Req.Body)⍱'application/json'begins lc ns.Req.GetHeader'content-type'
-                              :EndIf
-                              rc←fn HandleJSONRequest ns
-                          :Case 'rest'
-                              rc←fn HandleRESTRequest ns
-                          :EndSelect
-                          :If 0≠rc
-                              {}#.DRC.Close obj
-                              Connections.⎕EX obj
-                              →0
-                          :EndIf
-                      :EndIf
-                  :EndIf
-              :EndIf
-              obj Respond ns.Req
-              r←1
+
+              →resp⌿⍨ns.Req.Response.Status≠200
+
+            ⍝ Application-specified validation; default status 400 if not application set
+              →resp⌿⍨r⊣ns.Req.Fail 400×(ns.Req.Response.Status=200)∧r←0≠Validate ns.Req
+
+              fn←1↓'.'@('/'∘=)ns.Req.Endpoint
+
+            ⍝ Are we sessioned and requesting assassination?
+              →kill⌿⍨(0≠SessionTimeout)∧fn≡SessionStopEndpoint
+
+            ⍝ We support REST and JSON paradigms
+              →jsoon rest⌿⍨'json' 'rest'∊⊂lc Paradigm ⋄ 'Unknown Paradigm'⎕SIGNAL 11
+
+     jsoon:   →json⌿⍨HtmlInterface∧(⊂ns.Req.Endpoint)∊(,'/')'/favicon.ico' 
+              →resp⌿⍨'(Request method should be POST)'ns.Req.Fail 405×'post'≢ns.Req.Method
+              →resp⌿⍨'(Bad URI)'ns.Req.Fail 400×'/'≠⊃ns.Req.Endpoint
+              →resp⌿⍨'(Content-Type should be application/json)'ns.Req.Fail 400×(0∊⍴ns.Req.Body)⍱'application/json'begins lc ns.Req.GetHeader'content-type'
+     json:    rc←fn HandleJSONRequest ns ⋄ →chkrc
+     rest:    rc←fn HandleRESTRequest ns ⋄ →chkrc
+
+            ⍝ Something went wrong when handling the request body? Nuke from orbit.
+     chkrc:   →resp⌿⍨0=rc ⋄ {}#.DRC.Close obj ⋄ Connections.⎕EX obj ⋄ →0
+
+            ⍝ Murder they ask, murder they receive, if we know who; otherwise, Fail Level: 400
+     kill:    KillSession⍣(~ns.Req.Fail 400×0∊⍴sessId)⊢sessId←ns.Req.GetHeader SessionIdHeader
+
+            ⍝ All paths should lead to Rome...er, a response.
+     resp:    obj Respond ns.Req ⋄ r←1
+                  
           :EndIf
       :EndHold
     ∇


### PR DESCRIPTION
I found it difficult to track the flow of behaviors in the `ns.Req.Complete` section of the `HandleRequest` function. This style I'm using isn't the one that was being used before, and I apologize for that. If it's unacceptable, then we can rework it to use structured statements instead, but the vast majority of the code is a type of implicit return 1-armed if pattern, so I tried to keep the levels of nesting from getting crazy (the original code had 4+ levels of nesting, with long else branches). 

I believe this fixes #6 and fixes #4 , at least in part. It is also to set the stage to address #3 in a clean way. 

It also raises a solution for handling #5. We could either choose to always expunge the object at this point in the process, or we could choose to expunge the object on the outside always. I think it's probably cleaner to expunge the object in the same location as its creation, so I would prefer to move the expunge out of the inner `HandleRequest` function and just use the existing expunge operation on the outside. This depends on my correct understanding of the behavior of how this all works, though. 

I've done some rudimentary testing of this code. I'm not sure if there is a clean way to do a more sophisticated test, but these fixes address the issue that I was having with some stalled behavior in my front-end code. 

Let me know if you'd prefer this in a different format or style or otherwise find it acceptable or unacceptable for any reason. 