### PR TITLE
Add CORS support defaults into JSON Server

### DIFF
--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -566,6 +566,7 @@
       →0
      
      handle:
+      →0 If HandleCORSRequest ns.Req
       →0 If('No function specified')ns.Req.Fail 400×0∊⍴fn
       →0 If'(Content-Type should be application/json)'ns.Req.Fail 400×(0∊⍴ns.Req.Body)⍱'application/json'begins lc ns.Req.GetHeader'content-type'
       →0 If'(Cannot accept query parameters)'ns.Req.Fail 400×~0∊⍴ns.Req.QueryParams
@@ -647,6 +648,15 @@
       :If 'application/json'match⊃';'(≠⊆⊢)ns.Req.(Response.Headers GetHeader'content-type')
           ns.Req.Response ToJSON resp
       :EndIf
+    ∇
+
+    ∇ z←HandleCORSRequest req;defaults_to
+      defaults_to←{⍺ req.SetHeader⍣(~req.Response.Headers∊⍨⊂⍺)⊢⍵}
+      'Access-Control-Allow-Origin'defaults_to'*'
+      →0 If ~z←req.Method≡'options'
+      'Access-Control-Allow-Methods'defaults_to'POST,OPTIONS'
+      'Access-Control-Allow-Headers'defaults_to req.GetHeader'Access-Control-Request-Headers'
+      'Access-Control-Max-Age'defaults_to'86400'
     ∇
 
     ∇ response ToJSON data


### PR DESCRIPTION
This adds defaults for CORS support into the JSON server paradigm. Different handling can be accomplished by using the Validation step to adjust headers in the response. Additionally, if you don't want to use any defaults at all and just want to tweak your response completely, then you can signal an immediate response from the Validation frunction by return a -1 instead of a 0. Otherwise, you can set only the headers you want, and then use the defaults by returning 0 and letting the request fall through.