### PR TITLE
Verify request method in all location

### DIFF
--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -567,6 +567,7 @@
      
      handle:
       →0 If('No function specified')ns.Req.Fail 400×0∊⍴fn
+      →0 If('Unsupported request method')ns.Req.Fail 405×ns.Req.Method≢'post'
       →0 If'(Content-Type should be application/json)'ns.Req.Fail 400×(0∊⍴ns.Req.Body)⍱'application/json'begins lc ns.Req.GetHeader'content-type'
       →0 If'(Cannot accept query parameters)'ns.Req.Fail 400×~0∊⍴ns.Req.QueryParams
      


### PR DESCRIPTION
Fixes #9

There is already a check for invalid method calls when the HTML Interface is disabled, but this commit adds a check to the standard path to verify that we only work with 'post' methods in cases where we are called with a non-get method on a valid function but with an invalid request method.