### PR TITLE
PostProcessFn support - #94

### DIFF
--- a/Tests/test_PostProcess.dyalog
+++ b/Tests/test_PostProcess.dyalog
@@ -1,0 +1,29 @@
+﻿ r←test_PostProcess dummy;resp;ns;j
+ r←''
+ ns←⎕NS''
+ j←ns.##.Jarvis.New 8080
+ j.CodeLocation←ns
+ j.PostProcessFn←'PostJSON'
+ j.Paradigm←'JSON'
+ ns.(Endpoint←{⎕NS''})
+ ns.(PostJSON←{⍵.Message←'hello stranger'})
+ ns.(Get←{'hello'})
+ ns.(PostREST←{⍵.Response.Payload,←' stranger'})
+ :If 0≠⊃resp←j.Start
+     →end⊣r←'test_PostProcess failed to start Jarvis for JSON test: ',⍕resp
+ :EndIf
+ resp←HttpCommand.GetJSON'post' 'localhost:8080/Endpoint'
+ →stop↓0∊⍴r←{⍵.IsOK:'' ⋄ 'test_PostProcess (JSON) failed: ',⍕⍵}resp
+ →stop↓0∊⍴r←{0::'test_PostProcess (JSON) response not correct' ⋄ _←÷⍵.Message≡'hello stranger'}resp.Data
+ j.Stop
+ j.Paradigm←'REST'
+ j.PostProcessFn←'PostREST'
+ j.DefaultContentType←'text/plain'
+ :If 0≠⊃resp←j.Start
+     →end⊣r←'test_PostProcess failed to start Jarvis for REST test: ',⍕resp
+ :EndIf
+ resp←HttpCommand.Get'localhost:8080'
+ →stop↓0∊⍴r←{⍵.IsOK:'' ⋄ 'test_PostProcess (JSON) failed: ',⍕⍵}resp
+ →stop↓0∊⍴r←{0::'test_PostProcess (REST) response not correct' ⋄ ''⊣÷⍵≡'hello stranger'}resp.Data
+stop:j.Stop
+end:⎕EX'ns'

--- a/Tests/test_PostProcess.dyalog
+++ b/Tests/test_PostProcess.dyalog
@@ -6,7 +6,7 @@
  j.PostProcessFn←'PostJSON'
  j.Paradigm←'JSON'
  ns.(Endpoint←{⎕NS''})
- ns.(PostJSON←{⍵.Message←'hello stranger'})
+ ns.(PostJSON←{⍵.Response.Payload.Message←'hello stranger'})
  ns.(Get←{'hello'})
  ns.(PostREST←{⍵.Response.Payload,←' stranger'})
  :If 0≠⊃resp←j.Start


### PR DESCRIPTION
- Adds new "hook" function for post processing after endpoint call
- In REST mode - if the endpoint has not set the response payload but the endpoint has returned a non-empty result, then set the response payload to the endpoint result