### PR TITLE
"Friendlier" treatment of non-JSON response payloads

### DIFF
--- a/Tests/ContentTypes/test_contentTypes.aplf
+++ b/Tests/ContentTypes/test_contentTypes.aplf
@@ -1,0 +1,54 @@
+﻿ r←{req}test_contentTypes payload;here;resp;tests;rc;contentType;data;j;h;jarvis;ok
+⍝ As endpoints can return other than JSON payloads, make sure we catch data that Conga cannot transmit
+ :If 0∊⍴payload
+     :If 0=⎕NC'HttpCommand' ⋄ ⎕SE.UCMD'Load HttpCommand' ⋄ :EndIf
+     :If 0=⎕NC'Jarvis'
+         :If 0∊⍴here←1↓⊃'§'(=⊂⊢)⊃⊢/⎕NR⊃⎕SI ⍝ SALTed?
+         :AndIf 0∊⍴here←4⊃5179⌶⊃⎕SI
+             here←'/git/Jarvis/tests/ContentTypes/'
+         :EndIf
+         here←⊃1 ⎕NPARTS here
+         :If ~⎕NEXISTS jarvis←here,'../../Source/Jarvis.dyalog'
+             ('"',jarvis,'" not found')⎕SIGNAL 22
+         :Else
+             ⎕SE.Link.Import # jarvis
+         :EndIf
+     :EndIf
+     j←Jarvis.New''
+     j.CodeLocation←⊃⎕RSI
+     j.Start
+     h←HttpCommand.New'post'('http://localhost:',(⍕j.Port),'/test_contentTypes')
+     r←''
+    ⍝ test cases [;1] content-type, [;2] content, [;3] expected response
+     tests←[
+         'text/html;charset=utf-8' '<h2>Hello ⍵○⍴⌊⍋</h2>'(0 200)
+         'application/json'(name:'foo' ⋄ value:42)(0 200)
+         'application/octet-stream'(○1)(0 500)
+         'application/octet-stream'(83 ⎕DR○1)(0 200)
+     ]
+ ⍝ now test various content types
+     :For (contentType data rc) :In ↓tests
+         h.Params←(contentType:contentType ⋄ data:data)
+         resp←h.Run
+         :If resp.(rc HttpStatus)≢rc
+             r,←⊂h.Params.contentType,' failed: ',⍕resp
+         :EndIf
+         :If resp.IsOK
+             :Select contentType
+             :Case 'application/octet-stream'
+                 ok←data≡83 ⎕DR resp.Data
+             :Case 'application/json'
+                 ok←(⎕JSON data)≡resp.Data
+             :Else
+                 ok←data≡resp.Data
+             :EndSelect
+             :If ~ok ⋄ r,←⊂'content-type: ',contentType,' data: ',(⍕data),' did not match response data' ⋄ :EndIf
+         :EndIf
+     :EndFor
+
+     j.Stop
+     ⎕EX'j'
+ :Else ⍝ we have a payload
+     req.SetContentType payload.contentType
+     r←payload.data
+ :EndIf

--- a/Tests/ContentTypes/test_contentTypes.aplf
+++ b/Tests/ContentTypes/test_contentTypes.aplf
@@ -20,15 +20,16 @@
      h←HttpCommand.New'post'('http://localhost:',(⍕j.Port),'/test_contentTypes')
      r←''
     ⍝ test cases [;1] content-type, [;2] content, [;3] expected response
-     tests←[
-         'text/html;charset=utf-8' '<h2>Hello ⍵○⍴⌊⍋</h2>'(0 200)
-         'application/json'(name:'foo' ⋄ value:42)(0 200)
-         'application/octet-stream'(○1)(0 500)
-         'application/octet-stream'(83 ⎕DR○1)(0 200)
-     ]
+     tests←0 3⍴'' ''(0 200)
+     tests⍪←'text/html;charset=utf-8' '<h2>Hello ⍵○⍴⌊⍋</h2>'(0 200)
+     tests⍪←'application/json'(name:'foo' ⋄ value:42)(0 200)
+     tests⍪←'application/octet-stream'(○1)(0 500)
+     tests⍪←'application/octet-stream'(83 ⎕DR○1)(0 200)
+
  ⍝ now test various content types
      :For (contentType data rc) :In ↓tests
-         h.Params←(contentType:contentType ⋄ data:data)
+         h.Params←⎕NS''
+         h.Params.(contentType data)←contentType data
          resp←h.Run
          :If resp.(rc HttpStatus)≢rc
              r,←⊂h.Params.contentType,' failed: ',⍕resp


### PR DESCRIPTION
Handles 2 and 4-byte character types, Classic characters, and 2-byte integers in the range 0-255. Otherwise, it's up to the user's endpoint code to properly encode a non-standard response payload.