### PR TITLE
Allow dynamic HTMLInterface by making it a property

### DIFF
--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -6,7 +6,7 @@
 
     ∇ r←Version
       :Access public shared
-      r←'Jarvis' '1.20.6' '2025-09-02'
+      r←'Jarvis' '1.21.0' '2025-10-23'
     ∇
 
     ∇ Documentation
@@ -105,6 +105,7 @@
 
         ∇ set args;html;t;old_htmlInterface;old_htmlFolder;old_htmlDefaultPage
           old_htmlInterface←_htmlInterface
+          (_htmlEnabled _htmlRootFn _htmlFolder _htmlDefaultPage _homePage)←0 '' '' 'index.html' 1 ⍝ reset original field values
           :Select ⊃_htmlInterface←args.NewValue
           :Case 0 ⍝ explicitly no HTML interface, carry on
               _htmlEnabled←0


### PR DESCRIPTION
This changes HTMLInterface from being a field into being a property, backed by a private `_htmlInterface` field. It also adds the private field `_homepage` which is a boolean telling if we have a homepage to serve.

Note that the internal fields `_htmlInterface`, `_htmlFolder`, `_htmlDefaultPage` still can be temporarily wrong after setting `HTMLInterface` if `_rootfolder` hasn't been set correctly yet (happens during `Start`). The values are corrected (if relevant) in `Start`, and this aspect is thus no different from back when `HTMLInterface` was a field.