### PR TITLE
110 in rest mode provide mechanism to allow response to failed request to return a normal payload

### DIFF
--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -6,7 +6,7 @@
 
     ∇ r←Version
       :Access public shared
-      r←'Jarvis' '1.21.2' '2025-11-04'
+      r←'Jarvis' '1.22.0' '2026-01-08'
     ∇
 
     ∇ Documentation


### PR DESCRIPTION
The original design assumed that, on a failed REST request, the user would take care of setting the response content-type header and payload content and Jarvis would do nothing more with the response other than send it to the client.

A feature to let Jarvis do its "normal" processing has been added. By "normal" processing we mean:

- set the response content-type header to the default content type, if the header is not already set.
- if that content-type header is application/json, the response payload is converted to JSON