### PR TITLE
empty query parameters as empty character vectors #115

### DIFF
--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -1630,7 +1630,7 @@
           →0⍴⍨0∊⍴query
           query←'UTF-8'⎕UCS ⎕UCS query
           :If '='∊query ⍝ contains name=value?
-              params←URLDecode¨↑,∘(⊂'')¨@(1=≢¨)'='(≠⊆⊢)¨'&'(≠⊆⊢)
+              params←URLDecode¨↑{1 ¯1↓¨'='(≠⊆⊢)1⌽'  ',⍵}¨'&'(≠⊆⊢)query
           :Else
               params←URLDecode query
           :EndIf

--- a/Source/Jarvis.dyalog
+++ b/Source/Jarvis.dyalog
@@ -1630,7 +1630,7 @@
           →0⍴⍨0∊⍴query
           query←'UTF-8'⎕UCS ⎕UCS query
           :If '='∊query ⍝ contains name=value?
-              params←URLDecode¨2↑[2]↑'='(≠⊆⊢)¨'&'(≠⊆⊢)query
+              params←URLDecode¨↑,∘(⊂'')¨@(1=≢¨)'='(≠⊆⊢)¨'&'(≠⊆⊢)
           :Else
               params←URLDecode query
           :EndIf


### PR DESCRIPTION
Apparently this behaviour is specified for `application/x-www-form-urlencoded` but might not be generally defined for arbitrary URIs/HTTP. But, I think it's reasonable behaviour.

https://www.rfc-editor.org/info/rfc3986/#section-3.4
https://url.spec.whatwg.org/#urlencoded-parsing